### PR TITLE
Make the dependencies mandatory

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ url = https://pypi.org/project/tox-poetry-dev-dependencies/
 [options]
 install_requires =
     importlib-metadata
+    poetry-core
+    tox
 package_dir =
     = src
 packages = find:
@@ -31,14 +33,10 @@ packages = find:
 
 [options.entry_points]
 tox =
-    poetry_dev_dependencies = tox_poetry_dev_dependencies._hooks [plugin_tox]
+    poetry_dev_dependencies = tox_poetry_dev_dependencies._hooks
 
 
 [options.extras_require]
-plugin_tox =
-    poetry-core
-    tox
-#
 dev_package =
     twine
     wheel

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
     make review
 extras =
     dev_test
-    plugin_tox
 whitelist_externals =
     make
 
@@ -36,7 +35,6 @@ commands =
 extras =
     dev_package
     dev_test
-    plugin_tox
 usedevelop = True
 
 


### PR DESCRIPTION
Since this project can only be used as a plugin (of Tox to add some
compatibility with Poetry), there is no point in making the plugin
related dependencies optional. It is much simpler to make them
mandatory.

GitHub: fix #5