### PR TITLE
Improve CI setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,10 @@
     - 'python3 -m tox'
     - 'python3 -m tox -e package'
 
+'review py35':
+  extends: '.review'
+  image: 'python:3.6'
+
 'review py36':
   extends: '.review'
   image: 'python:3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dist: 'xenial'
 language: 'python'
 
 python:
+  - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,16 @@ strict = 1
 [metadata]
 author = sinoroc
 author_email = sinoroc.code+python@gmail.com
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Framework :: tox
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Software Development :: Testing
+    Typing :: Typed
 description = Let Tox know about Poetry's development dependencies
 license = Apache-2.0
 license_file = LICENSE.txt
@@ -29,6 +39,7 @@ install_requires =
 package_dir =
     = src
 packages = find:
+python_requires = ~= 3.5
 
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 
 [tox]
 envlist =
+    py35
     py36
     py37
     py38
@@ -12,7 +13,9 @@ isolated_build = True
 
 [testenv]
 commands =
-    make review
+    # Run review under Python 3.8 as it also includes linting and type checking
+    py38: make review
+    !py38: make test
 extras =
     dev_test
 whitelist_externals =
@@ -20,6 +23,7 @@ whitelist_externals =
 
 
 [testenv:py39]
+description = Outcome is ignored since Python 3.9 is not released yet
 ignore_outcome = True
 
 
@@ -31,6 +35,8 @@ extras =
 
 
 [testenv:develop]
+description = Use this environment for interactive development use (activate)
+#
 commands =
 extras =
     dev_package


### PR DESCRIPTION
Run linting and type checking (make review) only on Python 3.8, and
on the other environments run only the test suite (make test).

As a side effect, Python 3.5 can be enabled in CI.

Some metadata bits were added as well.

GitHub: closes #19
GitHub: refs #18
GitHub: refs #4