### PR TITLE
Allow skipping the creation of a virtual environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,15 @@
 0.0.3.dev0
 ==========
 
+* Add the ``poetry_experimental_no_virtual_env`` setting to allow skipping the creation of the virtual environment (experimental feature)
+
 
 0.0.2
 =====
 
 2020-09-28
 
-* Allow download from alternative repositories (without authentication) for pip via environment variables.
+* Allow download from alternative repositories (without authentication) for pip via environment variables
 
 
 0.0.1

--- a/README.rst
+++ b/README.rst
@@ -103,4 +103,23 @@ If pip's environment variables are already defined then they are not overwritten
     PIP_INDEX_URL=https://delta.example/simple tox
 
 
+``poetry_experimental_no_virtual_env``
+--------------------------------------
+
+*Experimental feature*
+
+Set the ``testenv`` setting ``poetry_experimental_no_virtual_env`` to ``True`` to skip the creation of a virtual environment for this test environment.
+
+.. code::
+
+    [testenv:real]
+    deps =
+    poetry_experimental_no_virtual_env = True
+    skip_install = True
+
+
+This might be useful in cases where all the required dependencies and tools are already available, i.e. they are already installed in global or user *site packages* directory, or maybe they are already installed directly in the system (via ``apt``, ``yum``, ``pacman``, etc.).
+
+For such environments it might be best to skip the installation of the project (``skip_install``) as well as keeping the list of dependencies empty (``deps``).
+
 .. EOF


### PR DESCRIPTION
Add the 'poetry_experimental_no_virtual_env' setting.
This feature is considered experimental.

GitHub: https://github.com/sinoroc/tox-poetry-dev-dependencies/issues/30