### PR TITLE
Add support for URL dependencies in lockfile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@
 0.0.5.dev0
 ==========
 
+* Add support for URL dependencies in lockfile
+
 
 0.0.4
 =====


### PR DESCRIPTION
GitHub: closes https://github.com/sinoroc/tox-poetry-dev-dependencies/issues/45