### PR TITLE
Fix issue when no 'dev' dependencies in 'lockfile'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@
 0.0.9.dev0
 ==========
 
+* Fix issue occuring when there are no 'dev' dependencies in the 'lockfile'
+
 
 0.0.8
 =====

--- a/src/tox_poetry_dev_dependencies/_hooks.py
+++ b/src/tox_poetry_dev_dependencies/_hooks.py
@@ -220,7 +220,7 @@ def _add_locked_deps(
         category: str,
 ) -> None:
     #
-    for dep_tuple in locked_deps[category]:
+    for dep_tuple in locked_deps.get(category, []):
         _add_locked_dep(env_config, dep_tuple)
 
 


### PR DESCRIPTION
GitHub: closes https://github.com/sinoroc/tox-poetry-dev-dependencies/issues/59